### PR TITLE
fix: move to Blocked state when Multus is disabled

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -123,7 +123,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 11
 
 
 logger = logging.getLogger(__name__)
@@ -384,6 +384,54 @@ class KubernetesClient:
             raise KubernetesMultusError(f"Could not patch statefulset {name}")
         logger.info("Multus annotation added to %s statefulset", name)
 
+    def unpatch_statefulset(
+        self,
+        name: str,
+        container_name: str,
+    ) -> None:
+        """Removes annotations, security privilege and NET_ADMIN capability from stateful set.
+
+        Args:
+            name: Statefulset name
+            container_name: Container name
+        """
+        try:
+            statefulset = self.client.get(res=StatefulSet, name=name, namespace=self.namespace)
+        except ApiError:
+            raise KubernetesMultusError(f"Could not get statefulset {name}")
+
+        container = Container(name=container_name)
+        container.securityContext = SecurityContext(
+            capabilities=Capabilities(
+                drop=[
+                    "NET_ADMIN",
+                ]
+            )
+        )
+        container.securityContext.privileged = False
+        statefulset_delta = StatefulSet(
+            spec=StatefulSetSpec(
+                selector=statefulset.spec.selector,  # type: ignore[attr-defined]
+                serviceName=statefulset.spec.serviceName,  # type: ignore[attr-defined]
+                template=PodTemplateSpec(
+                    metadata=ObjectMeta(annotations={"k8s.v1.cni.cncf.io/networks": "[]"}),
+                    spec=PodSpec(containers=[container]),
+                ),
+            )
+        )
+        try:
+            self.client.patch(
+                res=StatefulSet,
+                name=name,
+                obj=statefulset_delta,
+                patch_type=PatchType.APPLY,
+                namespace=self.namespace,
+                field_manager=self.__class__.__name__,
+            )
+        except ApiError:
+            raise KubernetesMultusError(f"Could not remove patches from statefulset {name}")
+        logger.info("Multus annotation removed from %s statefulset", name)
+
     def statefulset_is_patched(
         self,
         name: str,
@@ -493,6 +541,23 @@ class KubernetesClient:
                     return False
                 if privileged and not container.securityContext.privileged:
                     return False
+        return True
+
+    def multus_is_available(self) -> bool:
+        """Check whether Multus is enabled leveraging existence of NAD custom resource.
+
+        Returns:
+            bool: Whether Multus is enabled
+        """
+        try:
+            list(self.client.list(res=NetworkAttachmentDefinition, namespace=self.namespace))
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return False
+            else:
+                raise KubernetesMultusError(
+                    "Unexpected outcome when checking for Multus availability"
+                )
         return True
 
 
@@ -658,11 +723,15 @@ class KubernetesMultusCharmLib(Object):
         return "-".join(self.model.unit.name.rsplit("/", 1))
 
     def _on_remove(self, event: RemoveEvent) -> None:
-        """Deletes network attachment definitions.
+        """Deletes network attachment definitions and removes patch.
 
         Args:
             event: RemoveEvent
         """
+        self.kubernetes.unpatch_statefulset(
+            name=self.model.app.name,
+            container_name=self.container_name,
+        )
         for network_attachment_definition in self.network_attachment_definitions_func():
             if self.kubernetes.network_attachment_definition_is_created(
                 network_attachment_definition=network_attachment_definition
@@ -674,3 +743,11 @@ class KubernetesMultusCharmLib(Object):
     def delete_pod(self) -> None:
         """Delete the pod."""
         self.kubernetes.delete_pod(self._pod)
+
+    def multus_is_available(self) -> bool:
+        """Check whether Multus is enabled leveraging existence of NAD custom resource.
+
+        Returns:
+            bool: Whether Multus is enabled
+        """
+        return self.kubernetes.multus_is_available()

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -123,7 +123,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 
 logger = logging.getLogger(__name__)
@@ -351,7 +351,7 @@ class KubernetesClient:
                 )
             )
         if privileged:
-            container.securityContext.privileged = True
+            container.securityContext.privileged = True  # type: ignore[union-attr]
         statefulset_delta = StatefulSet(
             spec=StatefulSetSpec(
                 selector=statefulset.spec.selector,  # type: ignore[attr-defined]
@@ -489,12 +489,12 @@ class KubernetesClient:
             bool
         """
         if not self._annotations_contains_multus_networks(
-            annotations=pod.metadata.annotations,
+            annotations=pod.metadata.annotations,  # type: ignore[arg-type,union-attr]
             network_annotations=network_annotations,
         ):
             return False
         if not self._container_security_context_is_set(
-            containers=pod.spec.containers,
+            containers=pod.spec.containers,  # type: ignore[union-attr]
             container_name=container_name,
             cap_net_admin=cap_net_admin,
             privileged=privileged,
@@ -537,9 +537,9 @@ class KubernetesClient:
         """
         for container in containers:
             if container.name == container_name:
-                if cap_net_admin and "NET_ADMIN" not in container.securityContext.capabilities.add:
+                if cap_net_admin and "NET_ADMIN" not in container.securityContext.capabilities.add:  # type: ignore[operator,union-attr]  # noqa E501
                     return False
-                if privileged and not container.securityContext.privileged:
+                if privileged and not container.securityContext.privileged:  # type: ignore[union-attr]  # noqa E501
                     return False
         return True
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional
 
 from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
     KubernetesMultusCharmLib,
+    KubernetesMultusError,
     NetworkAnnotation,
     NetworkAttachmentDefinition,
 )
@@ -84,6 +85,12 @@ class RouterOperatorCharm(CharmBase):
             self.unit.status = BlockedStatus(
                 f"The following configurations are not valid: {invalid_configs}"
             )
+            return
+        try:
+            self._kubernetes_multus.is_ready()
+        except KubernetesMultusError as err:
+            self.unit.status = BlockedStatus(err.message)
+            event.defer()
             return
         self.on.nad_config_changed.emit()
         if not self._container.can_connect():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -277,23 +277,18 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-    @patch("lightkube.core.client.Client.get")
-    def test_given_multus_disabled_when_config_changed_then_status_is_blocked(self, patch_get):
-        patch_get.side_effect = httpx.HTTPStatusError(
+    @patch("lightkube.core.client.Client.list")
+    def test_given_multus_disabled_when_config_changed_then_status_is_blocked(self, patch_list):
+        patch_list.side_effect = httpx.HTTPStatusError(
             message="",
             request=httpx.Request(method="GET", url=""),
             response=httpx.Response(status_code=404),
         )
-        self.harness.set_can_connect(container="router", val=True)
-
-        self.harness.update_config()
+        self.harness.charm.on.install.emit()
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus(
-                "NetworkAttachmentDefinition resource not found. "
-                "You may need to install Multus CNI."
-            ),
+            BlockedStatus("Multus is not installed or enabled"),
         )
 
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_specified_in_nad(  # noqa: E501

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -45,8 +45,9 @@ def update_nad_labels(nads: list[NetworkAttachmentDefinition], app_name: str) ->
 
 
 class TestCharm(unittest.TestCase):
-    @patch("lightkube.core.client.GenericSyncClient")
-    def setUp(self, patch_k8s_client):
+    def setUp(self):
+        self.patch_k8s_client = patch("lightkube.core.client.GenericSyncClient")
+        self.patch_k8s_client.start()
         self.harness = testing.Harness(RouterOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,6 +5,7 @@ import json
 import unittest
 from unittest.mock import patch
 
+import httpx
 import pytest
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
@@ -273,6 +274,25 @@ class TestCharm(unittest.TestCase):
             BlockedStatus(
                 "The following configurations are not valid: "
                 "['core-gateway-ip', 'access-gateway-ip', 'ran-gateway-ip']"
+            ),
+        )
+
+    @patch("lightkube.core.client.Client.get")
+    def test_given_multus_disabled_when_config_changed_then_status_is_blocked(self, patch_get):
+        patch_get.side_effect = httpx.HTTPStatusError(
+            message="",
+            request=httpx.Request(method="GET", url=""),
+            response=httpx.Response(status_code=404),
+        )
+        self.harness.set_can_connect(container="router", val=True)
+
+        self.harness.update_config()
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus(
+                "NetworkAttachmentDefinition resource not found. "
+                "You may need to install Multus CNI."
             ),
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -52,11 +52,7 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
-    @patch("lightkube.core.client.Client.list")
-    def test_given_cant_connect_to_workload_when_config_changed_then_status_is_waiting(
-        self, patch_list
-    ):
-        patch_list.return_value = []
+    def test_given_cant_connect_to_workload_when_config_changed_then_status_is_waiting(self):
         self.harness.set_can_connect(container="router", val=False)
 
         self.harness.update_config()
@@ -66,14 +62,10 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for workload container to be ready"),
         )
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_multus_not_ready_when_config_changed_then_status_is_waiting(
-        self,
-        patch_is_ready,
-        patch_list,
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         self.harness.set_can_connect(container="router", val=True)
         patch_is_ready.return_value = False
 
@@ -84,12 +76,10 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for Multus to be ready"),
         )
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_multus_is_ready_when_config_changed_then_ip_forwarding_is_set(
-        self, patch_is_ready, patch_list
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         sysctl_called = False
         timeout = 0
         sysctl_cmd = ["sysctl", "-w", "net.ipv4.ip_forward=1"]
@@ -112,12 +102,10 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(sysctl_called)
         self.assertEqual(timeout, 30)
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_multus_is_ready_when_config_changed_then_iptables_rule_is_set(
-        self, patch_is_ready, patch_list
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         iptables_called = False
         timeout = 0
         iptables_cmd = [
@@ -151,12 +139,10 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(iptables_called)
         self.assertEqual(timeout, 30)
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_error_when_setting_ip_forwarding_when_config_changed_then_runtime_error_is_raised(  # noqa: E501
-        self, patch_is_ready, patch_list
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         stderr = "whatever error content"
         sysctl_cmd = ["sysctl", "-w", "net.ipv4.ip_forward=1"]
 
@@ -175,12 +161,10 @@ class TestCharm(unittest.TestCase):
             str(e.value), f"Could not set IP forwarding in workload container: {stderr}"
         )
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_ip_forwarding_set_correctly_when_config_changed_then_status_is_active(
-        self, patch_is_ready, patch_list
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         self.harness.handle_exec("router", ["sysctl"], result="net.ipv4.ip_forward = 1")
         self.harness.handle_exec("router", [], result=0)
         self.harness.set_can_connect(container="router", val=True)
@@ -190,12 +174,8 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    def test_given_empty_ip_when_config_changed_then_status_is_blocked(
-        self, patch_is_ready, patch_list
-    ):
-        patch_list.return_value = []
+    def test_given_empty_ip_when_config_changed_then_status_is_blocked(self, patch_is_ready):
         patch_is_ready.return_value = True
         self.harness.set_can_connect(container="router", val=True)
 
@@ -206,12 +186,10 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("The following configurations are not valid: ['core-gateway-ip']"),
         )
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_invalid_non_cidr_ip_when_config_changed_then_status_is_blocked(
-        self, patch_is_ready, patch_list
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         patch_is_ready.return_value = True
         self.harness.set_can_connect(container="router", val=True)
 
@@ -233,12 +211,10 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_ip_in_cidr_format_with_too_big_mask_when_config_changed_then_status_is_blocked(
-        self, patch_is_ready, patch_list
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         patch_is_ready.return_value = True
         self.harness.set_can_connect(container="router", val=True)
 
@@ -256,12 +232,10 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("The following configurations are not valid: ['access-gateway-ip']"),
         )
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_gateway_ip_in_cidr_format_with_too_small_mask_when_config_changed_then_status_is_blocked(  # noqa: E501
-        self, patch_is_ready, patch_list
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         patch_is_ready.return_value = True
         self.harness.set_can_connect(container="router", val=True)
 
@@ -281,12 +255,10 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-    @patch("lightkube.core.client.Client.list")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_string_gateway_ip_when_config_changed_then_status_is_blocked(
-        self, patch_is_ready, patch_list
+        self, patch_is_ready
     ):
-        patch_list.return_value = []
         patch_is_ready.return_value = True
         self.harness.set_can_connect(container="router", val=True)
 
@@ -313,43 +285,11 @@ class TestCharm(unittest.TestCase):
             request=httpx.Request(method="GET", url=""),
             response=httpx.Response(status_code=404),
         )
-        self.harness.update_config()
+        self.harness.charm.on.install.emit()
 
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Multus is not installed or enabled"),
-        )
-
-    @patch("lightkube.core.client.Client.list")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    def test_given_multus_disabled_then_enabled_when_update_status_then_status_is_active(
-        self, patch_is_ready, patch_list
-    ):
-        patch_list.side_effect = [
-            httpx.HTTPStatusError(
-                message="",
-                request=httpx.Request(method="GET", url=""),
-                response=httpx.Response(status_code=404),
-            ),
-            [],
-            [],
-        ]
-        patch_is_ready.return_value = True
-        self.harness.handle_exec("router", ["sysctl"], result="net.ipv4.ip_forward = 1")
-        self.harness.handle_exec("router", [], result=0)
-        self.harness.set_can_connect(container="router", val=True)
-        self.harness.update_config()
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Multus is not installed or enabled"),
-        )
-
-        self.harness.charm.on.update_status.emit()
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            ActiveStatus(),
         )
 
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_specified_in_nad(  # noqa: E501
@@ -426,11 +366,9 @@ class TestCharm(unittest.TestCase):
             self.assertEqual(VALID_MTU_SIZE_1, config["mtu"])
             self.assertIn(config["bridge"], ("access-br", "core-br", "ran-br"))
 
-    @patch("lightkube.core.client.Client.list")
     def test_given_default_config_when_config_is_updated_with_too_small_and_big_mtu_sizes_then_status_is_blocked(  # noqa: E501
-        self, patch_list
+        self,
     ):
-        patch_list.return_value = []
         self.harness.update_config(
             key_values={
                 "access-interface-mtu-size": TOO_SMALL_MTU_SIZE,
@@ -445,11 +383,9 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-    @patch("lightkube.core.client.Client.list")
     def test_given_default_config_when_config_is_updated_with_zero_mtu_sizes_then_status_is_blocked(  # noqa: E501
-        self, patch_list
+        self,
     ):
-        patch_list.return_value = []
         self.harness.set_leader(is_leader=True)
         self.harness.update_config(
             key_values={
@@ -467,14 +403,11 @@ class TestCharm(unittest.TestCase):
 
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
-    @patch("lightkube.core.client.Client.list")
     def test_given_container_can_connect_when_core_net_mtu_config_changed_to_a_different_valid_value_then_delete_pod_is_called(  # noqa: E501
         self,
-        patch_list,
         patch_delete_pod,
         patch_list_na_definitions,
     ):
-        patch_list.return_value = []
         self.harness.set_can_connect(container="router", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
@@ -484,14 +417,11 @@ class TestCharm(unittest.TestCase):
 
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
-    @patch("lightkube.core.client.Client.list")
     def test_given_container_can_connect_when_core_net_mtu_config_changed_to_different_valid_values_then_delete_pod_is_called_twice(  # noqa: E501
         self,
-        patch_list,
         patch_delete_pod,
         patch_list_na_definitions,
     ):
-        patch_list.return_value = []
         self.harness.set_can_connect(container="router", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
@@ -505,14 +435,11 @@ class TestCharm(unittest.TestCase):
 
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
-    @patch("lightkube.core.client.Client.list")
     def test_given_container_can_connect_when_core_net_mtu_config_changed_to_same_valid_value_multiple_times_then_delete_pod_is_called_once(  # noqa: E501
         self,
-        patch_list,
         patch_delete_pod,
         patch_list_na_definitions,
     ):
-        patch_list.return_value = []
         self.harness.set_can_connect(container="router", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)


### PR DESCRIPTION
# Description

This PR aims to fix #20. If Multus is not enabled when Pebble is ready or config-changed hook is triggered, move to Blocked state and defer the event.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library