### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,7 @@
 import ipaddress
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
     KubernetesMultusCharmLib,
@@ -360,7 +360,7 @@ class RouterOperatorCharm(CharmBase):
             return False
 
     def _get_core_interface_config(self) -> Optional[str]:
-        return self.model.config.get("core-interface")
+        return cast(Optional[str], self.model.config.get("core-interface"))
 
     def _get_core_interface_mtu_config(self) -> Optional[str]:
         """Get Core interface MTU size.
@@ -369,13 +369,13 @@ class RouterOperatorCharm(CharmBase):
             mtu_size (str/None): If MTU size is not configured return None
                                 If it is set, returns the configured value
         """
-        return self.model.config.get("core-interface-mtu-size")
+        return cast(Optional[str], self.model.config.get("core-interface-mtu-size"))
 
     def _get_core_gateway_ip_config(self) -> Optional[str]:
-        return self.model.config.get("core-gateway-ip")
+        return cast(Optional[str], self.model.config.get("core-gateway-ip"))
 
     def _get_access_interface_config(self) -> Optional[str]:
-        return self.model.config.get("access-interface")
+        return cast(Optional[str], self.model.config.get("access-interface"))
 
     def _get_access_interface_mtu_config(self) -> Optional[str]:
         """Get access interface MTU size.
@@ -384,13 +384,13 @@ class RouterOperatorCharm(CharmBase):
             mtu_size (str/None): If MTU size is not configured return None
                                 If it is set, returns the configured value
         """
-        return self.model.config.get("access-interface-mtu-size")
+        return cast(Optional[str], self.model.config.get("access-interface-mtu-size"))
 
     def _get_access_gateway_ip_config(self) -> Optional[str]:
-        return self.model.config.get("access-gateway-ip")
+        return cast(Optional[str], self.model.config.get("access-gateway-ip"))
 
     def _get_ran_interface_config(self) -> Optional[str]:
-        return self.model.config.get("ran-interface")
+        return cast(Optional[str], self.model.config.get("ran-interface"))
 
     def _get_ran_interface_mtu_config(self) -> Optional[str]:
         """Get RAN interface MTU size.
@@ -399,16 +399,16 @@ class RouterOperatorCharm(CharmBase):
             mtu_size (str/None): If MTU size is not configured return None
                                 If it is set, returns the configured value
         """
-        return self.model.config.get("ran-interface-mtu-size")
+        return cast(Optional[str], self.model.config.get("ran-interface-mtu-size"))
 
     def _get_ran_gateway_ip_config(self) -> Optional[str]:
-        return self.model.config.get("ran-gateway-ip")
+        return cast(Optional[str], self.model.config.get("ran-gateway-ip"))
 
     def _get_ue_subnet_config(self) -> Optional[str]:
-        return self.model.config.get("ue-subnet")
+        return cast(Optional[str], self.model.config.get("ue-subnet"))
 
     def _get_upf_core_ip_config(self) -> Optional[str]:
-        return self.model.config.get("upf-core-ip")
+        return cast(Optional[str], self.model.config.get("upf-core-ip"))
 
 
 def ip_is_valid(ip_address: str) -> bool:


### PR DESCRIPTION
# Description

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that validate the behaviour of the software N/A
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules N/A
- [ ] I have bumped the version of the library N/A