### PR TITLE
chore: replace mypy with pyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.idea
 .vscode/
 .coverage
-.mypy_cache/
 .tox/
 
 # Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,4 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 max-complexity = 10
 
 [tool.codespell]
-skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+skip = "build,lib,venv,icon.svg,.tox,.git,.ruff_cache,.coverage"

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,15 +9,16 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, cast
 
-from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
+from charms.kubernetes_charm_libraries.v0.multus import (
     KubernetesMultusCharmLib,
     NetworkAnnotation,
     NetworkAttachmentDefinition,
 )
-from charms.loki_k8s.v1.loki_push_api import LogForwarder  # type: ignore[import]
+from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from lightkube.models.meta_v1 import ObjectMeta
 from ops import ActiveStatus, BlockedStatus, CollectStatusEvent, EventSource, WaitingStatus
-from ops.charm import CharmBase, CharmEvents, EventBase
+from ops.charm import CharmBase, CharmEvents
+from ops.framework import EventBase
 from ops.main import main
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,7 @@ class KubernetesMultusCharmEvents(CharmEvents):
 class RouterOperatorCharm(CharmBase):
     """Charm the service."""
 
-    on = KubernetesMultusCharmEvents()
+    on = KubernetesMultusCharmEvents()  # type: ignore
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,9 +1,8 @@
 codespell
 coverage[toml]
-mypy
+pyright
 pytest
 pytest-asyncio>=v0.21.2  # https://github.com/pytest-dev/pytest/issues/12269
 pytest-operator
 PyYAML
 ruff
-types-PyYAML

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,7 +15,7 @@ certifi==2024.7.4
     #   -c requirements.txt
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   cryptography
     #   pynacl
@@ -65,12 +65,10 @@ markupsafe==2.1.5
     #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
-mypy==1.11.1
-    # via -r test-requirements.in
 mypy-extensions==1.0.0
-    # via
-    #   mypy
-    #   typing-inspect
+    # via typing-inspect
+nodeenv==1.9.1
+    # via pyright
 oauthlib==3.2.2
     # via
     #   kubernetes
@@ -117,6 +115,8 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
+pyright==1.1.374
+    # via -r test-requirements.in
 pytest==8.3.2
     # via
     #   -r test-requirements.in
@@ -166,12 +166,9 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-types-pyyaml==6.0.12.20240724
-    # via -r test-requirements.in
 typing-extensions==4.12.2
     # via
     #   -c requirements.txt
-    #   mypy
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -39,6 +39,7 @@ def update_nad_labels(nads: list[NetworkAttachmentDefinition], app_name: str) ->
         app_name: application name
     """
     for nad in nads:
+        assert nad.metadata
         nad.metadata.labels = {"app.juju.is/created-by": app_name}
 
 
@@ -280,6 +281,7 @@ class TestCharm:
         )
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
+            assert nad.spec
             config = json.loads(nad.spec["config"])
             assert "master" not in config
             assert "bridge" == config["type"]
@@ -301,6 +303,8 @@ class TestCharm:
         )
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
+            assert nad.spec
+            assert nad.metadata
             config = json.loads(nad.spec["config"])
             assert config["master"] == nad.metadata.name
             assert config["type"] == "macvlan"
@@ -315,6 +319,7 @@ class TestCharm:
         )
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
+            assert nad.spec
             config = json.loads(nad.spec["config"])
             assert "master" not in config
             assert "bridge" == config["type"]
@@ -331,6 +336,7 @@ class TestCharm:
         )
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
+            assert nad.spec
             config = json.loads(nad.spec["config"])
             assert "master" not in config
             assert "bridge" == config["type"]
@@ -409,6 +415,7 @@ class TestCharm:
         )
         update_nad_labels(nads_after_second_config_change, self.harness.charm.app.name)
         for nad in nads_after_second_config_change:
+            assert nad.metadata
             nad.metadata.labels = {"app.juju.is/created-by": self.harness.charm.app.name}
         self.mock_list_na_definitions.return_value = nads_after_second_config_change
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 [testenv:static]
 description = Run static analysis checks
 commands =
-    mypy {[vars]all_path} {posargs}
+    pyright {[vars]all_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
# Description

Replace mypy with pyright for static analysis

## Rationale

- Pyright is now the default static checker in charms.
- It allows us to get rid of the type ignores comment we had for charm library imports.
- It tends to be faster though this does not matter as much. 

## Reference
- https://github.com/microsoft/pyright
- https://github.com/canonical/charmcraft/blob/main/charmcraft/templates/init-kubernetes/tox.ini.j2

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library