### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,3 +6,4 @@ pytest-asyncio>=v0.21.2  # https://github.com/pytest-dev/pytest/issues/12269
 pytest-operator
 PyYAML
 ruff
+ops-scenario

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,4 +6,3 @@ pytest-asyncio>=v0.21.2  # https://github.com/pytest-dev/pytest/issues/12269
 pytest-operator
 PyYAML
 ruff
-ops-scenario

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,17 +12,18 @@ cachetools==5.5.0
     # via google-auth
 certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 codespell==2.3.0
     # via -r test-requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via -r test-requirements.in
 cryptography==43.0.1
     # via paramiko
@@ -30,7 +31,7 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-durationpy==0.7
+durationpy==0.9
     # via kubernetes
 executing==2.1.0
     # via stack-data
@@ -39,17 +40,21 @@ google-auth==2.35.0
 hvac==2.3.0
     # via juju
 idna==3.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.27.0
+ipython==8.28.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.2.0
     # via pytest-operator
 kubernetes==31.0.0
@@ -57,7 +62,9 @@ kubernetes==31.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
@@ -68,10 +75,6 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.0
-    # via ops-scenario
-ops-scenario==7.0.5
-    # via -r test-requirements.in
 packaging==24.1
     # via
     #   juju
@@ -114,7 +117,7 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.383
+pyright==1.1.384
     # via -r test-requirements.in
 pytest==8.3.3
     # via
@@ -133,11 +136,10 @@ pytz==2024.2
     # via pyrfc3339
 pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   juju
     #   kubernetes
-    #   ops
-    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
@@ -149,7 +151,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.6.8
+ruff==0.6.9
     # via -r test-requirements.in
 six==1.16.0
     # via
@@ -168,6 +170,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   -c requirements.txt
     #   pyright
     #   typing-inspect
 typing-inspect==0.9.0
@@ -180,7 +183,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via
+    #   -c requirements.txt
     #   kubernetes
-    #   ops
 websockets==13.1
     # via juju

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -75,6 +75,12 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
+ops==2.17.0
+    # via
+    #   -c requirements.txt
+    #   ops-scenario
+ops-scenario==7.0.5
+    # via -r test-requirements.in
 packaging==24.1
     # via
     #   juju
@@ -140,6 +146,8 @@ pyyaml==6.0.2
     #   -r test-requirements.in
     #   juju
     #   kubernetes
+    #   ops
+    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
@@ -185,5 +193,6 @@ websocket-client==1.8.0
     # via
     #   -c requirements.txt
     #   kubernetes
+    #   ops
 websockets==13.1
     # via juju

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import RouterOperatorCharm
 
@@ -26,6 +26,6 @@ class RouterUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=RouterOperatorCharm,
         )

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -3,8 +3,7 @@
 
 
 import pytest
-import scenario
-from ops import ActiveStatus, BlockedStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 
 from tests.unit.fixtures import RouterUnitTestFixtures
 
@@ -14,8 +13,8 @@ class TestCharmCollectUnitStatus(RouterUnitTestFixtures):
         self,
     ):
         self.mock_k8s_multus.multus_is_available.return_value = False
-        container = scenario.Container(name="router", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="router", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
         )
@@ -41,11 +40,9 @@ class TestCharmCollectUnitStatus(RouterUnitTestFixtures):
         self, config_param, value
     ):
         self.mock_k8s_multus.multus_is_available.return_value = True
-        container = scenario.Container(name="router", can_connect=True)
+        container = testing.Container(name="router", can_connect=True)
 
-        state_in = scenario.State(
-            leader=True, containers=[container], config={config_param: value}
-        )
+        state_in = testing.State(leader=True, containers=[container], config={config_param: value})
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
@@ -57,8 +54,8 @@ class TestCharmCollectUnitStatus(RouterUnitTestFixtures):
         self,
     ):
         self.mock_k8s_multus.multus_is_available.return_value = True
-        container = scenario.Container(name="router", can_connect=False)
-        state_in = scenario.State(
+        container = testing.Container(name="router", can_connect=False)
+        state_in = testing.State(
             leader=True,
             containers=[container],
         )
@@ -72,8 +69,8 @@ class TestCharmCollectUnitStatus(RouterUnitTestFixtures):
     ):
         self.mock_k8s_multus.multus_is_available.return_value = True
         self.mock_k8s_multus.is_ready.return_value = False
-        container = scenario.Container(name="router", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="router", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
         )
@@ -87,8 +84,8 @@ class TestCharmCollectUnitStatus(RouterUnitTestFixtures):
     ):
         self.mock_k8s_multus.multus_is_available.return_value = True
         self.mock_k8s_multus.is_ready.return_value = True
-        container = scenario.Container(name="router", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="router", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
         )

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -3,7 +3,7 @@
 
 
 import pytest
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import RouterUnitTestFixtures
 
@@ -14,23 +14,23 @@ class TestCharmConfigure(RouterUnitTestFixtures):
     ):
         self.mock_k8s_multus.multus_is_available.return_value = True
         self.mock_k8s_multus.is_ready.return_value = True
-        container = scenario.Container(
+        container = testing.Container(
             name="router",
             can_connect=True,
             execs={
-                scenario.Exec(
+                testing.Exec(
                     command_prefix=["iptables-legacy"],
                     return_code=0,
                     stdout="",
                 ),
-                scenario.Exec(
+                testing.Exec(
                     command_prefix=["sysctl"],
                     return_code=0,
                     stdout="net.ipv4.ip_forward = 1",
                 ),
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers={container},
         )
@@ -57,16 +57,16 @@ class TestCharmConfigure(RouterUnitTestFixtures):
     def test_error_when_setting_up_ip_forwarding_when_configure_then_error_raised(self, caplog):
         self.mock_k8s_multus.multus_is_available.return_value = True
         self.mock_k8s_multus.is_ready.return_value = True
-        container = scenario.Container(
+        container = testing.Container(
             name="router",
             can_connect=True,
             execs={
-                scenario.Exec(
+                testing.Exec(
                     command_prefix=["iptables-legacy"],
                     return_code=0,
                     stdout="",
                 ),
-                scenario.Exec(
+                testing.Exec(
                     command_prefix=["sysctl"],
                     return_code=0,
                     stdout="",
@@ -74,7 +74,7 @@ class TestCharmConfigure(RouterUnitTestFixtures):
                 ),
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers=[container],
         )

--- a/tests/unit/test_charm_remove.py
+++ b/tests/unit/test_charm_remove.py
@@ -3,18 +3,18 @@
 # See LICENSE file for licensing details.
 
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import RouterUnitTestFixtures
 
 
 class TestCharmRemove(RouterUnitTestFixtures):
     def test_given_unit_is_leader_when_remove_then_k8s_multus_is_removed(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="router",
             can_connect=False,
         )
-        state_in = scenario.State(leader=True, containers=[container])
+        state_in = testing.State(leader=True, containers=[container])
 
         self.ctx.run(self.ctx.on.remove(), state_in)
 


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we don't need to import it as a separate dependency. Here we use ops.testing instead of scenario. Both have the same API.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library